### PR TITLE
/invoices/{id}/generate dokumentációjának kiegészítése

### DIFF
--- a/docs/invoices.md
+++ b/docs/invoices.md
@@ -212,7 +212,10 @@ Every item can be set by the gross price. The API will automatically calculate t
 ```json
 {
   "success": true,
-  "id": 1444388311
+  "id": 1444388311,
+  "data": {
+      "id": 1444388311
+  }
 }
 ```
 


### PR DESCRIPTION
A díjbekérőből történő számla létrehozás dokumentációja hiányos. Szvsz érdemes kiegészíteni, mert a PHP API connector csak a data tömböt adja vissza, szóval én pl. elsőre azt gondoltam, hogy a connectorral nem kérhető le a létrehozott számla ID-ja. 